### PR TITLE
2.2.4? Consume tweets.csv from official twitter archives

### DIFF
--- a/lib/twitter_ebooks/model.rb
+++ b/lib/twitter_ebooks/model.rb
@@ -4,6 +4,7 @@
 require 'json'
 require 'set'
 require 'digest/md5'
+require 'csv'
 
 module Ebooks
   class Model
@@ -25,6 +26,11 @@ module Ebooks
         log "Reading json corpus from #{path}"
         lines = JSON.parse(content, symbolize_names: true).map do |tweet|
           tweet[:text]
+        end
+      elsif path.split('.')[-1] == "csv"
+        log "Reading CSV corpus from #{path}"
+        lines = CSV.read(path).drop(1).map do |tweet|
+          tweet[5]
         end
       else
         log "Reading plaintext corpus from #{path}"

--- a/lib/twitter_ebooks/version.rb
+++ b/lib/twitter_ebooks/version.rb
@@ -1,3 +1,3 @@
 module Ebooks
-  VERSION = "2.2.3"
+  VERSION = "2.2.4"
 end


### PR DESCRIPTION
In addition JSON check, we now check for consume path ending "csv" and assume this is `tweets.csv` from an official Twitter archive's base directory.

Fields per CSV row are: 
`tweet_id, in_reply_to_status_id, in_reply_to_user_id, timestamp, source, text, retweeted_status_id, retweeted_status_user_id, retweeted_status_timestamp, expanded_urls`  
we take each `text` field into `lines`.
