### PR TITLE
csv import now looks for text column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# twitter\_ebooks 2.2.4
+# twitter\_ebooks 2.2.5
 
 Rewrite of my twitter\_ebooks code. While the original was solely a tweeting Markov generator, this framework helps you build any kind of interactive twitterbot which responds to mentions/DMs.
 

--- a/lib/twitter_ebooks/model.rb
+++ b/lib/twitter_ebooks/model.rb
@@ -29,8 +29,10 @@ module Ebooks
         end
       elsif path.split('.')[-1] == "csv"
         log "Reading CSV corpus from #{path}"
+        header = CSV.read(path).first
+        text_col = header.index('text')
         lines = CSV.read(path).drop(1).map do |tweet|
-          tweet[5]
+          tweet[text_col]
         end
       else
         log "Reading plaintext corpus from #{path}"

--- a/lib/twitter_ebooks/version.rb
+++ b/lib/twitter_ebooks/version.rb
@@ -1,3 +1,3 @@
 module Ebooks
-  VERSION = "2.2.4"
+  VERSION = "2.2.5"
 end


### PR DESCRIPTION
Older versions of the Twitter archive .csv have the text column in a different place. Rather than assume the position of the text column, we now check for the first column named "text" and use that as the index. This might add more flexibility to future .csv column layouts as well.
