### PR TITLE
Fixed link to ebooks_example linking to twitter_ebooks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # twitter\_ebooks 2.2.4
 
-Rewrite of my twitter\_ebooks code. While the original was solely a tweeting Markov generator, this framework helps you build any kind of interactive twitterbot which responds to mentions/DMs. See [ebooks\_example](https://github.com/mispy/twitter_ebooks) for an example of a full bot.
+Rewrite of my twitter\_ebooks code. While the original was solely a tweeting Markov generator, this framework helps you build any kind of interactive twitterbot which responds to mentions/DMs. See [ebooks\_example](https://github.com/mispy/ebooks_example) for an example of a full bot.
 
 ## Installation
 


### PR DESCRIPTION
The README was linking to itself.
