### PR TITLE
Regex soft-retweet detection

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -70,7 +70,7 @@ module Ebooks
       # - The tweet mentions list contains our username
       # - The tweet is not being retweeted by somebody else
       # - Or soft-retweeted by somebody else
-      @mentions.map(&:downcase).include?(@bot.username.downcase) && !@tweet.retweeted_status? && !@tweet.text.start_with?('RT ') && !@tweet.text =~ /([`'‘’"“”]|RT|via|by|from)\s*@/i
+      @mentions.map(&:downcase).include?(@bot.username.downcase) && !@tweet.retweeted_status? && !@tweet.text.start_with?('RT ') && !@tweet.text.match(/([`'‘’"“”]|RT|via|by|from)\s*@/i)
     end
 
     # @param bot [Ebooks::Bot]


### PR DESCRIPTION
I added a regex to detect 'RT @' anywhere in the content of a tweet, in
case someone hides a RT in the middle of a tweet! As a bonus, it also
detects a bunch of different types of quotes as well as other things
people might use, like 'via,' 'by,' and 'from'!
