### PR TITLE
meta.media_uris

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -109,21 +109,18 @@ module Ebooks
     # Get an array of media uris in tweet.
     # @param size [String] A twitter image size to return. Supported sizes are thumb, small, medium (default), large
     # @return [Array<String>] image URIs included in tweet
-    def media_uris(*args)
-      # When there's no size given, the default is medium.
-      size = ''
-      # Was one given?
-      unless args.empty?
-        case args[0]
-        when 'thumb'
-          size = ':thumb'
-        when 'small'
-          size = ':small'
-        when 'medium'
-          size = ':medium'
-        when 'large'
-          size = ':large'
-        end
+    def media_uris(size_input = '')
+      case size_input
+      when 'thumb'
+        size = ':thumb'
+      when 'small'
+        size = ':small'
+      when 'medium'
+        size = ':medium'
+      when 'large'
+        size = ':large'
+      else
+        size = ''
       end
 
       # Start collecting uris.


### PR DESCRIPTION
Adds media_uris to tweet meta, which returns an array of strings
containing the URIs of media inside your tweet.

This is meant to be used with my improved pictweet! Basically, if you pass this function as a second parameter, you can use a block to do some processing of each image, and then upload it again right away!

```
pic_reply("Fancy!", meta(tweet).media_uris) do |filename|
  do_fancy_stuff filename
end
```

And just like that, you can automagically download all the media from a tweet, do_fancy_stuff to it, and upload it again, all in three lines!
