### PR TITLE
Remove * in default .gitignore

### DIFF
--- a/skeleton/.gitignore
+++ b/skeleton/.gitignore
@@ -1,1 +1,1 @@
-corpus/*
+corpus/


### PR DESCRIPTION
corpus/\* matches all files in the first level directory inside corpus,
so it would match corpus/lala.txt but not corpus/secret/lala.txt.

corpus/ matches the directory corpus itself, meaning that corpus/ and
everything inside of it shouldn't be uploaded.

corpus/*\* matches everything inside corpus, including contents of
subdirectories, while still allowing corpus/ itself to be uploaded. This
solves the initial problem I posed (with corpus/secret/lala.txt), but it
just feels tidier to just remove the entire folder.
