### PR TITLE
Fix direct messages

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -251,7 +251,7 @@ module Ebooks
       if ev.is_a? Twitter::DirectMessage
         return if ev.sender.screen_name.downcase == @username.downcase # Don't reply to self
         log "DM from @#{ev.sender.screen_name}: #{ev.text}"
-        fire(:direct_message, ev)
+        fire(:message, ev)
 
       elsif ev.respond_to?(:name) && ev.name == :follow
         return if ev.source.screen_name.downcase == @username.downcase


### PR DESCRIPTION
Someone renamed on_message to on_direct_message in bot.rb, but forgot to
update it in the template.

It used to be on_message in the template, so for less confusion, I think
it's preferable to just rename on_direct_message back. :o
