### PR TITLE
Removed reply_prefix from examples

### DIFF
--- a/skeleton/bots.rb
+++ b/skeleton/bots.rb
@@ -39,12 +39,12 @@ class MyBot < Ebooks::Bot
 
   def on_mention(tweet)
     # Reply to a mention
-    # reply(tweet, meta(tweet).reply_prefix + "oh hullo")
+    # reply(tweet, "oh hullo")
   end
 
   def on_timeline(tweet)
     # Reply to a tweet in the bot's timeline
-    # reply(tweet, meta(tweet).reply_prefix + "nice tweet")
+    # reply(tweet, "nice tweet")
   end
 end
 


### PR DESCRIPTION
> These methods now automatically add in reply_prefix in v3.

This is a simpler alternative to #58 
