### PR TITLE
Conditional reply_prefix for replies

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -379,7 +379,8 @@ module Ebooks
         end
 
         log "Replying to @#{ev.user.screen_name} with: #{meta.reply_prefix + text}"
-        tweet = twitter.update(meta.reply_prefix + text, opts.merge({in_reply_to_status_id: ev.id}))
+        text = meta.reply_prefix + text unless text.match /@#{Regexp.escape ev.user.screen_name}/i
+        tweet = twitter.update(text, opts.merge(in_reply_to_status_id: ev.id))
         conversation(tweet).add(tweet)
         tweet
       else


### PR DESCRIPTION
> Reply prefix is now only added if the recipient's screen_name isn't
> already in the tweet text.

This is a more robust alternative to #57 
