### PR TITLE
Enable "ebooks auth" to edit access token details of bots.rb

### DIFF
--- a/bin/ebooks
+++ b/bin/ebooks
@@ -331,19 +331,19 @@ STR
     # Process each line of bots.rb
     File.foreach 'bots.rb' do |line|
       # Strip out all whitespace to make matching easier.
-      stripped_line = line.gsub /\s+/, ''
+      stripped_line = line.gsub(/\s+/, '')
       # Drop comments if they exist.
-      stripped_line.gsub! /#[^"']*$/, ''
+      stripped_line.gsub!(/#[^"']*$/, '')
       case stage
       when :looking_for_bot
         # Matches default bot declarations, with an optional # comment at the end or a @ before their name.
-        if stripped_line.match /^\w+\.new\(?(["'])(@?)#{Regexp.escape username}\1\)?do\|(\w+)\|$/
+        if match_data = stripped_line.match(/^\w+\.new\(?(["'])(@?)#{Regexp.escape username}\1\)?do\|(\w+)\|$/)
           # Store the variable they're using for their bot.
-          bot_variable = $3
+          bot_variable = match_data[3]
           # Help them out if they put a @ in front of their bot's username
-          if $2 == '@'
+          if match_data[2] == '@'
             # It's safe to do another regex here because we don't use the last one's $ variables anymore.
-            line = line.gsub /(["'])@(#{Regexp.escape username})\1/, "\\1\\2\\1"
+            line = line.gsub(/(["'])@(#{Regexp.escape username})\1/, "\\1\\2\\1")
           end
           # Switch to next stage
           stage = :replacing_access_tokens
@@ -356,12 +356,12 @@ STR
         # Empty access token line
         when /^#{Regexp.escape bot_variable}\.access_token=(["'])\1$/
           # Replace pairs of quotes containing only spaces with the same type of quote containing token.
-          output += line.gsub /(['"])\s*\1/, "\\1#{access_token}\\1"
+          output += line.gsub(/(['"])\s*\1/, "\\1#{access_token}\\1")
           replaced_token = true
         # Empty access token secret line
         when /^#{Regexp.escape bot_variable}\.access_token_secret=(["'])\1$/
           # Replace pairs of quotes containing only spaces with the same type of quote containing token secret.
-          output += line.gsub /(['"])\s*\1/, "\\1#{access_token_secret}\\1"
+          output += line.gsub(/(['"])\s*\1/, "\\1#{access_token_secret}\\1")
           replaced_secret = true
         # Another bot definition
         when /^\w+\.new\(?["'](@?)\w*["']\)?do\|(\w+)\|$/
@@ -382,8 +382,8 @@ STR
       end
 
       # Also try to detect user's last defined bot class
-      if stripped_line.match /class(\w+)<Ebooks::Bot/
-        bot_class = $1
+      if match_data = stripped_line.match(/class(\w+)<Ebooks::Bot/)
+        bot_class = match_data[1]
       end
     end
 
@@ -393,7 +393,7 @@ STR
       return false if bot_class.empty?
 
       # Generate a new bot definition.
-      output += <<-PuddiDOC.gsub /^ {6}/, ''
+      output += <<-PuddiDOC.gsub(/^ {6}/, '')
 
       # Make a #{bot_class} and attach it to an account
       #{bot_class}.new('#{username}') do |bot|

--- a/bin/ebooks
+++ b/bin/ebooks
@@ -210,10 +210,15 @@ STR
     end
 
     access_token = request_token.get_access_token(oauth_verifier: pin)
+    token_username = access_token.params['screen_name']
 
-    log "Account authorized successfully. Make sure to put these in your bots.rb!\n" +
-         "  access token: #{access_token.token}\n" +
-         "  access token secret: #{access_token.secret}"
+    if fill_access_token token_username, access_token.token, access_token.secret
+      log "@#{token_username}'s details have been updated in bots.rb. For your reference:"
+    else
+      log "@#{token_username} authorized successfully. Make sure to put these in your bots.rb!"
+    end
+    log "  access token: #{access_token.token}\n" +
+        "  access token secret: #{access_token.secret}"
   end
 
   HELP.console = <<-STR
@@ -309,6 +314,83 @@ STR
     if Ebooks::Bot.all.empty?
       puts "Couldn't find any bots! Please make sure bots.rb instantiates at least one bot."
     end
+  end
+
+  def self.fill_access_token(username, access_token, access_token_secret)
+    # This keeps track of what we're doing.
+    stage = :looking_for_bot
+    # This is used to hold onto the user's bot variable later.
+    bot_variable = ''
+    # This will be passed out to File.write later.
+    output = ''
+    # This keeps track of whether we can tell the user we succeeded or not.
+    replaced_token = false
+    replaced_secret = false
+    # Process each line of bots.rb
+    File.foreach 'bots.rb' do |line|
+      # Strip out all whitespace to make matching easier.
+      stripped_line = line.gsub /\s+/, ''
+      case stage
+      when :looking_for_bot
+        # Matches default bot declarations, with an optional # comment at the end or a @ before their name.
+        if stripped_line.match /^\w+\.new\(?["'](@?)#{Regexp.escape username}["']\)?do\|(\w+)\|(?:#.*)?$/
+          # Warn them if they put a @ in front of their bot's username
+          log "Warning: A '@' was detected at the beginning of #{username}'s username in bots.rb." if $1 == '@'
+          # Store the variable they're using for their bot.
+          bot_variable = $2
+          # Switch to next stage
+          stage = :replacing_access_tokens
+        end
+        # Add current line to output.
+        output += line
+      when :replacing_access_tokens
+        # Find out if we're looking at an access_token_line
+        case stripped_line
+        # Empty access token line
+        when /^#{Regexp.escape bot_variable}\.access_token=(["'])\1(?:#.*)$?/
+          # Replace pairs of quotes containing only spaces with the same type of quote containing token.
+          output += line.gsub /(['"])\s*\1/, "#{$1}#{access_token}#{$1}"
+          replaced_token = true
+        # Empty access token secret line
+        when /^#{Regexp.escape bot_variable}\.access_token_secret=(["'])\1(?:#.*)$?/
+          # Replace pairs of quotes containing only spaces with the same type of quote containing token secret.
+          output += line.gsub /(['"])\s*\1/, "#{$1}#{access_token_secret}#{$1}"
+          replaced_secret = true
+        # Another bot definition
+        when /^\w+\.new\(?["'](@?)\w*["']\)?do\|(\w+)\|(?:#.*)?$/
+          # This file is either nonstandard or something weird happened. Have the user manually edit it.
+          return false
+        # End of bot definition
+        when /^end(?:#.*)?$/
+          # Remember that we saw an end.
+          stage = :done
+          output += line
+        # Other lines
+        else
+          output += line
+        end
+      when :done
+        # We're outside of bot definition now, so just copy the rest.
+        output += line
+      end
+    end
+
+    # Don't do anything if stage isn't done, because it means something weird happened or the user's bots.rb is non-standard.
+    return false unless stage == :done
+
+    # Is there any point in replacing file?
+    if replaced_token || replaced_secret
+      # Replace it.
+      File.open 'bots.rb', 'w' do |file|
+        file.write output
+      end
+    end
+
+    # Did we replace both lines successfully?
+    replaced_token && replaced_secret
+  rescue => e
+    # The file is probably unavailable for reading, so user will have to manually input.
+    false
   end
 
   def self.command(args)

--- a/bin/ebooks
+++ b/bin/ebooks
@@ -213,7 +213,7 @@ STR
     token_username = access_token.params['screen_name']
 
     if fill_access_token token_username, access_token.token, access_token.secret
-      log "@#{token_username}'s details have been updated in bots.rb. For your reference:"
+      log "Please check that @#{token_username}'s details have been updated in bots.rb correctly."
     else
       log "@#{token_username} authorized successfully. Make sure to put these in your bots.rb!"
     end
@@ -321,6 +321,8 @@ STR
     stage = :looking_for_bot
     # This is used to hold onto the user's bot variable later.
     bot_variable = ''
+    # This holds the last bot class we found. Only used if normal bot detection fails.
+    bot_class = ''
     # This will be passed out to File.write later.
     output = ''
     # This keeps track of whether we can tell the user we succeeded or not.
@@ -330,14 +332,19 @@ STR
     File.foreach 'bots.rb' do |line|
       # Strip out all whitespace to make matching easier.
       stripped_line = line.gsub /\s+/, ''
+      # Drop comments if they exist.
+      stripped_line.gsub! /#[^"']*$/, ''
       case stage
       when :looking_for_bot
         # Matches default bot declarations, with an optional # comment at the end or a @ before their name.
-        if stripped_line.match /^\w+\.new\(?["'](@?)#{Regexp.escape username}["']\)?do\|(\w+)\|(?:#.*)?$/
-          # Warn them if they put a @ in front of their bot's username
-          log "Warning: A '@' was detected at the beginning of #{username}'s username in bots.rb." if $1 == '@'
+        if stripped_line.match /^\w+\.new\(?(["'])(@?)#{Regexp.escape username}\1\)?do\|(\w+)\|$/
           # Store the variable they're using for their bot.
-          bot_variable = $2
+          bot_variable = $3
+          # Help them out if they put a @ in front of their bot's username
+          if $2 == '@'
+            # It's safe to do another regex here because we don't use the last one's $ variables anymore.
+            line = line.gsub /(["'])@(#{Regexp.escape username})\1/, "\\1\\2\\1"
+          end
           # Switch to next stage
           stage = :replacing_access_tokens
         end
@@ -347,21 +354,21 @@ STR
         # Find out if we're looking at an access_token_line
         case stripped_line
         # Empty access token line
-        when /^#{Regexp.escape bot_variable}\.access_token=(["'])\1(?:#.*)$?/
+        when /^#{Regexp.escape bot_variable}\.access_token=(["'])\1$/
           # Replace pairs of quotes containing only spaces with the same type of quote containing token.
-          output += line.gsub /(['"])\s*\1/, "#{$1}#{access_token}#{$1}"
+          output += line.gsub /(['"])\s*\1/, "\\1#{access_token}\\1"
           replaced_token = true
         # Empty access token secret line
-        when /^#{Regexp.escape bot_variable}\.access_token_secret=(["'])\1(?:#.*)$?/
+        when /^#{Regexp.escape bot_variable}\.access_token_secret=(["'])\1$/
           # Replace pairs of quotes containing only spaces with the same type of quote containing token secret.
-          output += line.gsub /(['"])\s*\1/, "#{$1}#{access_token_secret}#{$1}"
+          output += line.gsub /(['"])\s*\1/, "\\1#{access_token_secret}\\1"
           replaced_secret = true
         # Another bot definition
-        when /^\w+\.new\(?["'](@?)\w*["']\)?do\|(\w+)\|(?:#.*)?$/
+        when /^\w+\.new\(?["'](@?)\w*["']\)?do\|(\w+)\|$/
           # This file is either nonstandard or something weird happened. Have the user manually edit it.
           return false
         # End of bot definition
-        when /^end(?:#.*)?$/
+        when /^end$/
           # Remember that we saw an end.
           stage = :done
           output += line
@@ -373,6 +380,32 @@ STR
         # We're outside of bot definition now, so just copy the rest.
         output += line
       end
+
+      # Also try to detect user's last defined bot class
+      if stripped_line.match /class(\w+)<Ebooks::Bot/
+        bot_class = $1
+      end
+    end
+
+    # Were we unable to find our bot at all?
+    if stage == :looking_for_bot
+      # We can't do anything if we didn't detect a class definiton either.
+      return false if bot_class.empty?
+
+      # Generate a new bot definition.
+      output += <<-PuddiDOC.gsub /^ {6}/, ''
+
+      # Make a #{bot_class} and attach it to an account
+      #{bot_class}.new('#{username}') do |bot|
+        bot.access_token = '#{access_token}' # Token connecting the app to this account
+        bot.access_token_secret = '#{access_token_secret}' # Secret connecting the app to this account
+      end
+      PuddiDOC
+
+      # Well, now we're pretty much done.
+      stage = :done
+      replaced_token = true
+      replaced_secret = true
     end
 
     # Don't do anything if stage isn't done, because it means something weird happened or the user's bots.rb is non-standard.
@@ -388,7 +421,7 @@ STR
 
     # Did we replace both lines successfully?
     replaced_token && replaced_secret
-  rescue => e
+  rescue
     # The file is probably unavailable for reading, so user will have to manually input.
     false
   end

--- a/skeleton/bots.rb
+++ b/skeleton/bots.rb
@@ -49,7 +49,7 @@ class MyBot < Ebooks::Bot
 end
 
 # Make a MyBot and attach it to an account
-MyBot.new("{{BOT_NAME}}") do |bot|
-  bot.access_token = "" # Token connecting the app to this account
-  bot.access_token_secret = "" # Secret connecting the app to this account
+MyBot.new('{{BOT_NAME}}') do |bot|
+  bot.access_token = '' # Token connecting the app to this account
+  bot.access_token_secret = '' # Secret connecting the app to this account
 end


### PR DESCRIPTION
> Added a new method called from ebooks auth that will automatically fill
> a bot's access_token and access_token_secret variables inside ebooks.rb,
> assuming the file is in the same format as the one in /skeleton

It makes me sad that you don't like #50, but I wrote you a method that will make `ebooks auth` automatically insert access token details into `bots.rb`. It has a few conditions for working:
- Users must have typed their bot's name into a line with a format close to default:
  
  ``` ruby
  SomeBot.new("somebot_ebooks") do |bot| # Double-quotes
  AnyBot.new('somebot_ebooks') do |bot| # Single-quotes
  AnotherBot.new 'somebot_ebooks' do |bot| # No parentheses
  ```
- Lines that will have details filled in must have nothing between their quotes.
  
  ``` ruby
  bot.access_token = "" # See, quotes are empty.
  bot.access_token_secret = ' ' # Whitespace and comments are okay.
  ```
- These will only work if there's a line with just an end and nothing else on it below them.
  
  ``` ruby
  end
  ```
- If the bot that got authed couldn't be found at all, but a bot class that was extended from `Ebooks::Bot` could be found, a new block based on the default block will be added at the end of their file.
  
  ``` ruby
  # Make a TheirBotClass and attach it to an account
  TheirBotClass.new('their_username') do |bot|
    bot.access_token = 'their token' # Token connecting the app to this account
    bot.access_token_secret = 'their token secret' # Secret connecting the app to this account
  end
  ```
