### PR TITLE
Allow custom user formatting of log output

### DIFF
--- a/skeleton/bots.rb
+++ b/skeleton/bots.rb
@@ -46,6 +46,11 @@ class MyBot < Ebooks::Bot
     # Reply to a tweet in the bot's timeline
     # reply(tweet, "nice tweet")
   end
+
+  def on_log(bot_name, log_message)
+    # Add a timestamp to console logs this bot makes
+    # "#{Time.now.strftime('%c')} - #{bot_name}: #{log_message}"
+  end
 end
 
 # Make a MyBot and attach it to an account


### PR DESCRIPTION
> Allows users to create an on_log method in their bots that determines
> what their log outputs look like.

The current log format is still the default, and this implementation reverts to it if `on_log` is missing or does not return a string containing `log_message`. If it returns anything other than that, it'll also provide a helpful warning so users know that their method is getting detected, but just not working like it should.

Example usage (with a timestamp borrowed from #55):

``` ruby
  def on_log(bot_name, log_message)
    # Add a timestamp to console logs this bot makes
    "#{Time.now.strftime('%c')} - #{bot_name}: #{log_message}"
  end
```
