### PR TITLE
Fixed log entries for replies

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -383,8 +383,8 @@ module Ebooks
           return false
         end
 
-        log "Replying to @#{ev.user.screen_name} with: #{meta.reply_prefix + text}"
         text = meta.reply_prefix + text unless text.match /@#{Regexp.escape ev.user.screen_name}/i
+        log "Replying to @#{ev.user.screen_name} with: #{text}"
         tweet = twitter.update(text, opts.merge(in_reply_to_status_id: ev.id))
         conversation(tweet).add(tweet)
         tweet


### PR DESCRIPTION
> I didn't notice that log entries were also manually adding
> meta.reply_prefix on.

This moves that line that checks if we need to add reply_prefix above logging as well, so that check can check for both of them! :3
