### PR TITLE
Fix typo in Bot#unfollow

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -427,7 +427,7 @@ module Ebooks
     # @param user [String] username or user id
     def unfollow(user, *args)
       log "Unfollowing #{user}"
-      twiter.unfollow(user, *args)
+      twitter.unfollow(user, *args)
     end
 
     # Tweet something


### PR DESCRIPTION
`twiter` does not exist