### PR TITLE
Fix deprecation warning, update 'interesting keywords' favoriting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ The secondary function is the "interesting keywords" list. For example, I use th
 
 ``` ruby
 top100 = model.keywords.take(100)
-tokens = Ebooks::NLP.tokenize(tweet[:text])
+tokens = Ebooks::NLP.tokenize(tweet.text)
 
 if tokens.find { |t| top100.include?(t) }
-  bot.favorite(tweet[:id])
+  favorite(tweet)
 end
 ```
 


### PR DESCRIPTION
I get a deprecation warning when using the 'interesting keywords' favorite function example. This fixes that.
```bots.rb:57:in `on_mention': [DEPRECATION] #[:text] is deprecated. Use #text to fetch the value.```

I also the unprefixed favorite function, with the tweet object as a param, which is consistent with the other examples in the documentation.