### PR TITLE
@user variable

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -294,7 +294,7 @@ module Ebooks
           log "@#{ev.source.screen_name} #{ev.name.to_s}d: #{ev.target_object.text}"
           fire(ev.name, ev.source, ev.target_object)
         when :user_update
-          update_user_object ev.source
+          update_myself ev.source
         end
       when Twitter::Streaming::DeletedTweet
         # Pass
@@ -304,7 +304,7 @@ module Ebooks
     end
 
     # Updates @user and calls on_user_update. Make sure it's the right person before you call it.
-    def update_user_object(new_me = twitter.user)
+    def update_myself(new_me = twitter.user)
       new_me = twitter.user unless new_me.is_a? Twitter::User
 
       @user = new_me
@@ -335,7 +335,7 @@ module Ebooks
       # Save old name
       old_name = username
       # Load user object and actual username
-      update_user_object
+      update_myself
       # Warn about mismatches unless it was clearly intensional
       log "warning: bot expected to be @#{old_name} but connected to @#{username}" unless username == old_name || old_name.empty?
 

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -304,13 +304,10 @@ module Ebooks
       end
     end
 
-    # Updates @user and calls on_user_update. Make sure it's the right person before you call it.
+    # Updates @user and calls on_user_update.
     def update_myself(new_me = twitter.user)
-      new_me = twitter.user unless new_me.is_a? Twitter::User
-
       @user = new_me
       @username = user.name
-
       fire(:user_update)
     end
 
@@ -337,7 +334,7 @@ module Ebooks
       old_name = username
       # Load user object and actual username
       update_myself
-      # Warn about mismatches unless it was clearly intensional
+      # Warn about mismatches unless it was clearly intentional
       log "warning: bot expected to be @#{old_name} but connected to @#{username}" unless username == old_name || old_name.empty?
 
       fire(:startup)

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -252,6 +252,7 @@ module Ebooks
       case ev
       when Array # Initial array sent on first connection
         log "Online!"
+        fire(:connect)
         return
       when Twitter::DirectMessage
         return if ev.sender.id == @user.id # Don't reply to self

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -307,7 +307,7 @@ module Ebooks
     # Updates @user and calls on_user_update.
     def update_myself(new_me = twitter.user)
       @user = new_me if @user.nil? || new_me.id == @user.id
-      @username = user.name
+      @username = user.screen_name
       fire(:user_update)
     end
 

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -306,7 +306,7 @@ module Ebooks
 
     # Updates @user and calls on_user_update.
     def update_myself(new_me = twitter.user)
-      @user = new_me
+      @user = new_me if @user.nil? || new_me.id == @user.id
       @username = user.name
       fire(:user_update)
     end

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -260,15 +260,17 @@ module Ebooks
         fire(:message, ev)
 
       elsif ev.respond_to?(:name)
-        if ev.name == :follow
+        case ev.name
+        when :follow
           return if ev.source.screen_name.downcase == @username.downcase
           log "Followed by #{ev.source.screen_name}"
           fire(:follow, ev.source)
-
-        elsif ev.name == :favorite || ev.name == :unfavorite
+        when :favorite, :unfavorite
           return if ev.source.screen_name.downcase == @username.downcase # Ignore our own favorites
           log "@#{ev.source.screen_name} #{ev.name.to_s}d: #{ev.target_object.text}"
           fire(ev.name, ev.source, ev.target_object)
+        when :user_update
+          update_user_object ev.source
         end
 
       elsif ev.is_a? Twitter::Tweet

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -254,12 +254,12 @@ module Ebooks
         log "Online!"
         return
       when Twitter::DirectMessage
-        return if ev.sender.screen_name.downcase == @username.downcase # Don't reply to self
+        return if ev.sender.id == @user.id # Don't reply to self
         log "DM from @#{ev.sender.screen_name}: #{ev.text}"
         fire(:message, ev)
       when Twitter::Tweet
         return unless ev.text # If it's not a text-containing tweet, ignore it
-        return if ev.user.screen_name.downcase == @username.downcase # Ignore our own tweets
+        return if ev.user.id == @user.id # Ignore our own tweets
 
         meta = meta(ev)
 
@@ -286,11 +286,11 @@ module Ebooks
       when Twitter::Streaming::Event
         case ev.name
         when :follow
-          return if ev.source.screen_name.downcase == @username.downcase
+          return if ev.source.id == @user.id
           log "Followed by #{ev.source.screen_name}"
           fire(:follow, ev.source)
         when :favorite, :unfavorite
-          return if ev.source.screen_name.downcase == @username.downcase # Ignore our own favorites
+          return if ev.source.id == @user.id # Ignore our own favorites
           log "@#{ev.source.screen_name} #{ev.name.to_s}d: #{ev.target_object.text}"
           fire(ev.name, ev.source, ev.target_object)
         when :user_update

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -252,7 +252,7 @@ module Ebooks
       case ev
       when Array # Initial array sent on first connection
         log "Online!"
-        fire(:connect)
+        fire(:connect, ev)
         return
       when Twitter::DirectMessage
         return if ev.sender.id == @user.id # Don't reply to self

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -308,6 +308,7 @@ module Ebooks
     def update_myself(new_me = twitter.user)
       @user = new_me if @user.nil? || new_me.id == @user.id
       @username = user.screen_name
+      log 'User information updated'
       fire(:user_update)
     end
 


### PR DESCRIPTION
This is another bit of code I wrote for my own bot but I thought I'd share!

I noticed that twitter_ebooks yells at you if your bot's username doesn't match the one in your script, and then changes it for you anyway. To stop it from yelling at me, I decided to call twitter.user myself first to grab my bot's username. That's a complete waste of one (of 180) api calls, though, so I thought I'd edit twitter_ebooks to actually save a user variable!

This also introduces a new event, on_user_update, an equivalent of which I use extensively in my bot, and it also keeps @user up to date nearly instantly after people update their bots!