### PR TITLE
Require fileutils

### DIFF
--- a/bin/ebooks
+++ b/bin/ebooks
@@ -3,6 +3,7 @@
 
 require 'twitter_ebooks'
 require 'ostruct'
+require 'fileutils'
 
 module Ebooks::Util
   def pretty_exception(e)


### PR DESCRIPTION
'ebooks new <reponame>' doesn't work without declaring fileutils as a requirement, at least on vanilla Fedora 21 box.