### PR TITLE
Require fileutils

### DIFF
--- a/bin/ebooks
+++ b/bin/ebooks
@@ -3,6 +3,7 @@
 
 require 'twitter_ebooks'
 require 'ostruct'
+require 'fileutils'
 
 module Ebooks::Util
   def pretty_exception(e)


### PR DESCRIPTION
It's the little things that count on some systems. A whole bunch of twitter_ebooks things just wouldn't under Fedora unless I force fileutils as a requirement.