### PR TITLE
Don't reply to blacklisted users

### DIFF
--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -267,6 +267,8 @@ module Ebooks
         if blacklisted?(ev.user.screen_name)
           log "Blocking blacklisted user @#{ev.user.screen_name}"
           @twitter.block(ev.user.screen_name)
+          # we don't want to reply to blacklisted users, so return
+          return
         end
 
         # Avoid responding to duplicate tweets


### PR DESCRIPTION
Solves issue https://github.com/mispy/twitter_ebooks/issues/98 where bots could end up in an infinite reply chain with blacklisted users.