### PR TITLE
Fixed bug where an empty corpus .json would cause archive command to fail

### DIFF
--- a/lib/twitter_ebooks/archive.rb
+++ b/lib/twitter_ebooks/archive.rb
@@ -49,7 +49,7 @@ module Ebooks
 
       @client = client || make_client
 
-      if File.exists?(@path)
+      if (File.exists?(@path) && !File.zero?(@path))
         @filetext = File.read(@path, :encoding => 'utf-8')
         @tweets = JSON.parse(@filetext, symbolize_names: true)
         log "Currently #{@tweets.length} tweets for #{@username}"


### PR DESCRIPTION
Previously, running an archive command when an empty .json file existed generated `A JSON text must at least contain two octets! (JSON::ParserError)`.

This has been resolved by checking not only that the file exists but that it has contents, using .zero?.