### PR TITLE
Get full tweet text instead of the truncated one 

### DIFF
--- a/lib/twitter_ebooks/archive.rb
+++ b/lib/twitter_ebooks/archive.rb
@@ -82,6 +82,7 @@ module Ebooks
       opts = {
         count: 200,
         #include_rts: false,
+        tweet_mode: "extended",
         trim_user: true
       }
 
@@ -107,6 +108,7 @@ module Ebooks
       else
         @tweets ||= []
         @tweets = tweets.map(&:attrs).each { |tw|
+          tw[:text] = tw[:full_text]
           tw.delete(:entities)
         } + @tweets
       end


### PR DESCRIPTION
Since twitter allows to write 140 characters even if the tweet includes a photo, tweet quote or mention to users, the api by default sends a shortened version of the tweet so that it only contains 140 characters, and that is not something desirable for us because it removes some words.