### PR TITLE
HTTP and HTTPS in keyword list fix

### DIFF
--- a/lib/twitter_ebooks/nlp.rb
+++ b/lib/twitter_ebooks/nlp.rb
@@ -3,7 +3,6 @@ require 'fast-stemmer'
 require 'highscore'
 require 'htmlentities'
 
-require 'pry'
 module Ebooks
   module NLP
     # We deliberately limit our punctuation handling to stuff we can do consistently
@@ -88,7 +87,7 @@ module Ebooks
     # @return [Highscore::Keywords]
     def self.keywords(text)
       # Preprocess to remove stopwords (highscore's blacklist is v. slow)
-			text = NLP.tokenize(text).reject { |t| stopword?(t) || t.start_with?('http') }.join(' ')
+      text = NLP.tokenize(text).reject { |t| stopword?(t) || t.start_with?('http') }.join(' ')
 
       text = Highscore::Content.new(text)
 

--- a/lib/twitter_ebooks/nlp.rb
+++ b/lib/twitter_ebooks/nlp.rb
@@ -3,6 +3,7 @@ require 'fast-stemmer'
 require 'highscore'
 require 'htmlentities'
 
+require 'pry'
 module Ebooks
   module NLP
     # We deliberately limit our punctuation handling to stuff we can do consistently
@@ -87,7 +88,7 @@ module Ebooks
     # @return [Highscore::Keywords]
     def self.keywords(text)
       # Preprocess to remove stopwords (highscore's blacklist is v. slow)
-      text = NLP.tokenize(text).reject { |t| stopword?(t) }.join(' ')
+			text = NLP.tokenize(text).reject { |t| stopword?(t) || t.start_with?('http') }.join(' ')
 
       text = Highscore::Content.new(text)
 


### PR DESCRIPTION
Before, the keyword function would leave in http and https. They were in the stopwords file, but they were never on their own-- just as part of a URL. This is a little inelegant, but it fixes the problem. 