### PR TITLE
280 character fix/blacklisting capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Once you have a model, the primary use is to produce statements and related resp
 
 ``` ruby
 > model = Ebooks::Model.load("model/0xabad1dea.model")
-> model.make_statement(140)
+> model.make_statement(280)
 => "My Terrible Netbook may be the kind of person who buys Starbucks, but this Rackspace vuln is pretty straight up a backdoor"
 > model.make_response("The NSA is coming!", 130)
 => "Hey - someone who claims to be an NSA conspiracy"

--- a/lib/twitter_ebooks/archive.rb
+++ b/lib/twitter_ebooks/archive.rb
@@ -82,7 +82,8 @@ module Ebooks
       opts = {
         count: 200,
         #include_rts: false,
-        trim_user: true
+        trim_user: true,
+        tweet_mode: 'extended'
       }
 
       opts[:since_id] = @tweets[0][:id] unless @tweets.nil?

--- a/lib/twitter_ebooks/bot.rb
+++ b/lib/twitter_ebooks/bot.rb
@@ -95,7 +95,7 @@ module Ebooks
       @reply_mentions = ([ev.user.screen_name] + reply_mentions).uniq
 
       @reply_prefix = @reply_mentions.map { |m| '@'+m }.join(' ') + ' '
-      @limit = 140 - @reply_prefix.length
+      @limit = 280 - @reply_prefix.length
 
       mless = ev.text
       begin

--- a/lib/twitter_ebooks/model.rb
+++ b/lib/twitter_ebooks/model.rb
@@ -100,7 +100,8 @@ module Ebooks
 
     def initialize
       @tokens = []
-
+      @banned_words_file ||= 'banned_words.txt'
+      @banned_words ||= File.exists?(@banned_words_file) ? File.read(@banned_words_file).split : []
       # Reverse lookup tiki by token, for faster generation
       @tikis = {}
     end
@@ -117,6 +118,20 @@ module Ebooks
         return @tikis[token] = @tokens.length-1
       end
     end
+
+    # Set the banned words list for the model
+    # @param path [String]
+    def set_banned_words(path = 'banned_words.txt')
+      return if @banned_words_file == path
+      @banned_words_file = path
+      if File.exists?(@banned_words_file)
+        @banned_words = File.read(@banned_words_file).split
+        log "Successfully loaded banned words list #{path}"
+      else
+        log "Error: Banned words list #{path} does not exist"
+      end
+    end
+
 
     # Convert a body of text into arrays of tikis
     # @param text [String]
@@ -246,7 +261,11 @@ module Ebooks
     # @param limit Integer how many chars we have left
     def valid_tweet?(tikis, limit)
       tweet = NLP.reconstruct(tikis, @tokens)
-      tweet.length <= limit && !NLP.unmatched_enclosers?(tweet)
+      found_banned = @banned_words.any? do |word|
+        re = Regexp.new("\\b#{word}\\b", "i")
+        re.match tweet
+      end
+      tweet.length <= limit && !NLP.unmatched_enclosers?(tweet) && !found_banned
     end
 
     # Generate some text
@@ -282,7 +301,13 @@ module Ebooks
       tweet = NLP.reconstruct(tikis, @tokens)
 
       if retries >= retry_limit
-        log "Unable to produce valid non-verbatim tweet; using \"#{tweet}\""
+        log "Unable to produce valid non-verbatim tweet; result was \"#{tweet}\""
+        if valid_tweet?(tikis, limit)
+          log "Tweet contains no banned words; sending anyways"
+        else
+          log "Tweet contains banned words or is invalid; replacing with dummy message"
+          tweet = "Sorry, try again."
+        end
       end
 
       fix tweet

--- a/lib/twitter_ebooks/model.rb
+++ b/lib/twitter_ebooks/model.rb
@@ -142,7 +142,11 @@ module Ebooks
       if path.split('.')[-1] == "json"
         log "Reading json corpus from #{path}"
         lines = JSON.parse(content).map do |tweet|
-          tweet['text']
+          if tweet.key?('full_text')
+            tweet['full_text']
+          else
+            tweet['text']
+          end
         end
       elsif path.split('.')[-1] == "csv"
         log "Reading CSV corpus from #{path}"
@@ -205,7 +209,11 @@ module Ebooks
         if path.split('.')[-1] == "json"
           log "Reading json corpus from #{path}"
           l = JSON.parse(content).map do |tweet|
-            tweet['text']
+            if tweet.key?('full_text')
+              tweet['full_text']
+            else
+              tweet['text']
+            end
           end
           lines.concat(l)
         elsif path.split('.')[-1] == "csv"
@@ -246,7 +254,7 @@ module Ebooks
     # @param generator [SuffixGenerator, nil]
     # @param retry_limit [Integer] how many times to retry on invalid tweet
     # @return [String]
-    def make_statement(limit=140, generator=nil, retry_limit=10)
+    def make_statement(limit=280, generator=nil, retry_limit=10)
       responding = !generator.nil?
       generator ||= SuffixGenerator.build(@sentences)
 
@@ -316,7 +324,7 @@ module Ebooks
     # @param limit [Integer] characters available for response
     # @param sentences [Array<Array<Integer>>]
     # @return [String]
-    def make_response(input, limit=140, sentences=@mentions)
+    def make_response(input, limit=280, sentences=@mentions)
       # Prefer mentions
       relevant, slightly_relevant = find_relevant(sentences, input)
 

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -10,13 +10,13 @@ describe Ebooks::Model do
 
     it "generates a tweet" do
       s = @model.make_statement
-      expect(s.length).to be <= 140
+      expect(s.length).to be <= 280
       puts s
     end
 
     it "generates an appropriate response" do
       s = @model.make_response("hi")
-      expect(s.length).to be <= 140
+      expect(s.length).to be <= 280
       expect(s.downcase).to include("hi")
       puts s
     end


### PR DESCRIPTION
With Twitter increasing the character limit from 140 to 280 a while back, I figured twitter_ebooks needed some updating (as did some others apparently, which I only saw afterward). I made the ebooks archive command fetch from twitter in expanded mode (by default it truncated long tweets) and increased the hard character limits in places.

I also added blacklisting/banned word capability based on https://blog.boodoo.co/2014/06/27/how-to-make-an-_ebooks.html
I converted it to reading .txt files (default is "banned_words.txt"), and added an optional command to change what file the banlist is read from for potential bots with multiple ban lists.
