### PR TITLE
Remove "Building: sentence" when making tweets.

### DIFF
--- a/lib/twitter_ebooks/suffix.rb
+++ b/lib/twitter_ebooks/suffix.rb
@@ -22,9 +22,9 @@ module Ebooks
       @bigrams = {}
 
       @sentences.each_with_index do |tikis, i|
-        if (i % 10000 == 0) then
-          log ("Building: sentence #{i} of #{sentences.length}")
-        end
+#        if (i % 10000 == 0) then
+#          log ("Building: sentence #{i} of #{sentences.length}")
+#        end
         last_tiki = INTERIM
         tikis.each_with_index do |tiki, j|
           @unigrams[last_tiki] ||= []


### PR DESCRIPTION
When running the bot via `ebooks start`, about half the screen real estate gets wasted by these `Building: sentence 0 of 986` lines. This fixes that.